### PR TITLE
fix: config value from environment variable "type is not map"

### DIFF
--- a/templates/vikunja.yaml
+++ b/templates/vikunja.yaml
@@ -12,6 +12,8 @@ service:
         port: 3456
         protocol: HTTP
 
+enableServiceLinks: false
+
 podSecurityContext:
   fsGroup: 1000
 


### PR DESCRIPTION
Fixes go-vikunja/vikunja#719
more context there

The service link functionality adds environment variables such as the following:
```
VIKUNJA_PORT=tcp://10.43.164.115:3456
VIKUNJA_PORT_3456_TCP_ADDR=10.43.164.115
VIKUNJA_PORT_3456_TCP_PORT=3456
```
Due to this, the mapping logic first attempted to set the `PORT` field to `tcp://...`, later followed by nested fields under the `PORT` name, therefore breaking the assumption that the path entries are all maps.

The startup failure was resolved in https://github.com/go-vikunja/vikunja/commit/d7d277f9b653db5fa5eddeb38fbeda1318ba5b0d, this PR fixes [the related error logs](https://gist.githubusercontent.com/SIMULATAN/661869884e2e99c2df6460e262a3b72b/raw/3923506e3268a0dfa474e3e6362f03aab7579577/vikunja.log)