### PR TITLE
Update README.md with valid installation method

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,19 +24,11 @@ The Configmap name in the cluster stays the same.
 
 ## Quickstart
 
-The Helm chart is published to GitHub Container Registry. To install it:
+The Helm chart is published to [GitHub Container Registry](https://github.com/go-vikunja/helm-chart/pkgs/container/helm-chart%2Fvikunja). To install it:
 
-1. Add the Helm repository:
-
-```bash
-helm repo add vikunja oci://ghcr.io/go-vikunja/helm-chart
-helm repo update
-```
-
-2. Install the chart:
 
 ```bash
-helm install vikunja vikunja/vikunja -f values.yaml
+helm install vikunja oci://ghcr.io/go-vikunja/helm-chart -f values.yaml
 ```
 
 Define ingress settings according to your controller to access the application.


### PR DESCRIPTION
fixes #2 

The OCI are not repositories, but containers themselves. To install them there's not need to add the repository, they just need to be installed.

There is a way of handling that in the "traditional" way, but needs some extra steps, e.g. [Homarr](https://homarr-labs.github.io/charts/charts/homarr/).