### PR TITLE
fix: add SQL DB URL to the Vikunja pod env variables

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -56,7 +56,7 @@ vikunja:
     # You could also use MySQL or SQLite, but we recommend PostgreSQL.
     # https://vikunja.io/docs/config-options/#type
     VIKUNJA_DATABASE_TYPE: "postgres"
-    VIKUNJA_DATABASE_HOST: "{{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local"
+    VIKUNJA_DATABASE_HOST: "{{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local:{{ coalesce .Values.postgresql.global.postgresql.service.ports.postgresql .Values.postgresql.service.ports.postgresql }}"
     VIKUNJA_DATABASE_USER: "{{ coalesce .Values.postgresql.global.postgresql.auth.username .Values.postgresql.auth.username }}"
     VIKUNJA_DATABASE_PASSWORD: "{{ coalesce .Values.postgresql.global.postgresql.auth.password .Values.postgresql.auth.password }}"
     VIKUNJA_DATABASE_NAME: "{{ coalesce .Values.postgresql.global.postgresql.auth.database .Values.postgresql.auth.database }}"

--- a/values.yaml
+++ b/values.yaml
@@ -56,6 +56,7 @@ vikunja:
     # You could also use MySQL or SQLite, but we recommend PostgreSQL.
     # https://vikunja.io/docs/config-options/#type
     VIKUNJA_DATABASE_TYPE: "postgres"
+    VIKUNJA_DATABASE_HOST: "{{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local"
     VIKUNJA_DATABASE_USER: "{{ coalesce .Values.postgresql.global.postgresql.auth.username .Values.postgresql.auth.username }}"
     VIKUNJA_DATABASE_PASSWORD: "{{ coalesce .Values.postgresql.global.postgresql.auth.password .Values.postgresql.auth.password }}"
     VIKUNJA_DATABASE_NAME: "{{ coalesce .Values.postgresql.global.postgresql.auth.database .Values.postgresql.auth.database }}"


### PR DESCRIPTION
# tl;dr

Currently the environment variable `VIKUNJA_DATABASE_HOST` is not set, and by default the app tries to connect to `localhost`. The PR sets the environment variable to the hostname exposed by the PostgreSQL service and port.

# details

Initially I was seeing that the app wasn't able to start because of being unable to connect top PostgreSQL database. I figured that it's not set anywhere in the settings, so not surprised. Following the [Vikunja docs](https://vikunja.io/docs/config-options/#1-database-host) I am adding the environment variable that passes the full address by default.

The hostname is generated from the regular [CoreDNS](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#services), i.e. `<service name>.<namespace>.svc.cluster.local`, and the port is added from either the top-level postgress override or the local override, defaulting to standard PostgreSQL port.

# testing

Deployed with the updated values in my local k3s cluster, it deployed correctly and started the pod. I still haven't tested all the interaction (i.e. writes, reads), but I'm seeing the entry log for the migrations being successful.