### PR TITLE
fix: add the default PostgreSQL port

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -81,6 +81,9 @@ postgresql:
     username: vikunja
     database: vikunja
     password: vikunja
+  service:
+    ports:
+      postgresql: 5432
 
 #  ┬─┐┬─┐┬─┐o┐─┐
 #  │┬┘├─ │ ││└─┐


### PR DESCRIPTION
In the #4 I forgot to push a commit with the default PostgreSQL port. Unless it's explicitly added to the default `values.yaml` the whole chart installation will fail.