### PR TITLE
feat: add additional objects option

### DIFF
--- a/templates/additional-objects.yaml
+++ b/templates/additional-objects.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.additionalObjects }}
+---
+{{- tpl (toYaml . ) $ }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -110,3 +110,5 @@ typesense:
     repository: docker.io/typesense/typesense
     tag: 0.25.1
     pullPolicy: IfNotPresent
+
+additionalObjects: []


### PR DESCRIPTION
Allows for defining additional objects in case they are needed, e.g. Traefik middleware for Ingress:

```
additionalObjects:
  - apiVersion: traefik.io/v1alpha1
    kind: Middleware
    metadata:
      name: enforce-https
    spec:
      redirectScheme:
        scheme: https
        permanent: true
```

This does not mess with existing parameters and is entirely on the side. Running `helm template` provides additional object:

```
# Source: vikunja/templates/additional-objects.yaml
apiVersion: traefik.io/v1alpha1
kind: Middleware
metadata:
  name: enforce-https
spec:
  redirectScheme:
    permanent: true
    scheme: https
```