### PR TITLE
Fixing some mistyped configuration

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -49,7 +49,7 @@ vikunja:
           redis:
             # These configuration values will automatically apply
             # if the integrated Redis is enabled below (redis.enabled)
-            host: "http://{{ printf "%s-redis-master" .Release.Name }}:6379"
+            host: "{{ printf "%s-redis-master" .Release.Name }}:6379"
             db: "{{ .Release.Name }}"
   env:
     # To utilize a secret in the environment variables, you can do something like the following: https://github.com/bjw-s/helm-charts/blob/a081de53024d8328d1ae9ff7e4f6bc500b0f3a29/charts/library/common/values.yaml#L141-L145

--- a/values.yaml
+++ b/values.yaml
@@ -59,7 +59,7 @@ vikunja:
     VIKUNJA_DATABASE_HOST: "{{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local:{{ coalesce .Values.postgresql.global.postgresql.service.ports.postgresql .Values.postgresql.service.ports.postgresql }}"
     VIKUNJA_DATABASE_USER: "{{ coalesce .Values.postgresql.global.postgresql.auth.username .Values.postgresql.auth.username }}"
     VIKUNJA_DATABASE_PASSWORD: "{{ coalesce .Values.postgresql.global.postgresql.auth.password .Values.postgresql.auth.password }}"
-    VIKUNJA_DATABASE_NAME: "{{ coalesce .Values.postgresql.global.postgresql.auth.database .Values.postgresql.auth.database }}"
+    VIKUNJA_DATABASE_DATABASE: "{{ coalesce .Values.postgresql.global.postgresql.auth.database .Values.postgresql.auth.database }}"
 
 ##########################
 # END VIKUNJA COMPONENTS #


### PR DESCRIPTION
While deploying, I had two issues that this PR should address:

- `redis.host` should have only host:port. Originally, there was a http://... url and startup failed with a "too many semicolon" or something like that. Official vikunja documentation states that host:port is required, so this should be consistent with documentation
- `VIKUNJA_DATABASE_DATABASE` is the proper name (according to official documentation). The pod was failing because it was not being able to connect to "vikunja" table (I am NOT using this default, but loading it from a secret). After changing the incorrect VIKUNJA_DATABASE_NAME to VIKUNJA_DATABASE_DATABASE migrations could run and pod started successfully.

The impact of this PR should be minimal and should not break any existing working installations.