### PR TITLE
fix(values): handle missing postgresql.global keys safely

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -56,10 +56,10 @@ vikunja:
     # You could also use MySQL or SQLite, but we recommend PostgreSQL.
     # https://vikunja.io/docs/config-options/#type
     VIKUNJA_DATABASE_TYPE: "postgres"
-    VIKUNJA_DATABASE_HOST: "{{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local:{{ coalesce .Values.postgresql.global.postgresql.service.ports.postgresql .Values.postgresql.service.ports.postgresql }}"
-    VIKUNJA_DATABASE_USER: "{{ coalesce .Values.postgresql.global.postgresql.auth.username .Values.postgresql.auth.username }}"
-    VIKUNJA_DATABASE_PASSWORD: "{{ coalesce .Values.postgresql.global.postgresql.auth.password .Values.postgresql.auth.password }}"
-    VIKUNJA_DATABASE_DATABASE: "{{ coalesce .Values.postgresql.global.postgresql.auth.database .Values.postgresql.auth.database }}"
+    VIKUNJA_DATABASE_HOST: "{{ .Release.Name }}-postgresql.{{ .Release.Namespace }}.svc.cluster.local:{{ coalesce (dig \"postgresql\" \"service\" \"ports\" \"postgresql\" \"\" .Values.postgresql.global) .Values.postgresql.service.ports.postgresql }}"
+    VIKUNJA_DATABASE_USER: "{{ coalesce (dig \"postgresql\" \"auth\" \"username\" \"\" .Values.postgresql.global) .Values.postgresql.auth.username }}"
+    VIKUNJA_DATABASE_PASSWORD: "{{ coalesce (dig \"postgresql\" \"auth\" \"password\" \"\" .Values.postgresql.global) .Values.postgresql.auth.password }}"
+    VIKUNJA_DATABASE_DATABASE: "{{ coalesce (dig \"postgresql\" \"auth\" \"database\" \"\" .Values.postgresql.global) .Values.postgresql.auth.database }}"
 
 ##########################
 # END VIKUNJA COMPONENTS #


### PR DESCRIPTION
Setting postgresql to disabled but then not providing postgresql settings broke, so then you need to do something like this:

```
postgresql:
  enabled: false
  # Keep global auth populated to avoid nil pointer errors in chart templates when disabled.
  global:
    postgresql:
      auth:
        username: "vikunja"
        password: "change-me"
        database: "vikunja"
      service:
        ports:
          postgresql: 5432
```