### PR TITLE
chore: sync Chart.yaml with existing git tags to fix workflow deadlock

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -8,8 +8,8 @@ description: |-
   The open-source, self-hostable to-do app. Organize everything, on all platforms.
 annotations:
   category: TaskTracker
-version: 2.1.0
-appVersion: 2.1.0
+version: 2.2.0
+appVersion: 2.2.0
 kubeVersion: ">= 1.19"
 dependencies:
 - name: common


### PR DESCRIPTION
This PR manually updates Chart.yaml to version 2.2.0 to resolve a deadlock in the `check-version` workflow.

**The issue:**
The workflow is currently trying to bump the version from 2.1.0 to 2.2.0, but since the git tag 2.2.0 already exists, the process aborts to avoid conflicts. This prevents the chart from being updated to the latest Vikunja version (2.3.0).

**The fix:**
By syncing the file version with the latest tag, we allow the workflow to resume its normal cycle. In the next run, it will correctly bump the version to 2.3.0 and trigger a new release.