### PR TITLE
fix: open PR instead of pushing directly to main

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -99,8 +99,21 @@ jobs:
           sed -i "s/^version: .*/version: ${CHART_VERSION}/" Chart.yaml
           sed -i "s/^appVersion: .*/appVersion: ${APP_VERSION}/" Chart.yaml
 
+      - name: Check if PR already exists
+        id: check_pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          EXISTING=$(gh pr list --head "chore/update-vikunja-${{ steps.latest_release.outputs.version }}" --json number --jq '.[0].number')
+          if [ -n "$EXISTING" ]; then
+            echo "PR #$EXISTING already exists, skipping"
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Commit and push to branch
-        if: steps.compare.outputs.needs_update == 'true' && steps.check_tag.outputs.exists == 'false'
+        if: steps.compare.outputs.needs_update == 'true' && steps.check_tag.outputs.exists == 'false' && steps.check_pr.outputs.exists == 'false'
         id: push_branch
         run: |
           APP_VERSION="${{ steps.latest_release.outputs.version }}"
@@ -117,7 +130,7 @@ jobs:
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
 
       - name: Create pull request
-        if: steps.compare.outputs.needs_update == 'true' && steps.check_tag.outputs.exists == 'false'
+        if: steps.compare.outputs.needs_update == 'true' && steps.check_tag.outputs.exists == 'false' && steps.check_pr.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   check-and-update:
@@ -98,17 +99,33 @@ jobs:
           sed -i "s/^version: .*/version: ${CHART_VERSION}/" Chart.yaml
           sed -i "s/^appVersion: .*/appVersion: ${APP_VERSION}/" Chart.yaml
 
-      - name: Commit, tag and push
+      - name: Commit and push to branch
         if: steps.compare.outputs.needs_update == 'true' && steps.check_tag.outputs.exists == 'false'
+        id: push_branch
         run: |
           APP_VERSION="${{ steps.latest_release.outputs.version }}"
           CHART_VERSION="${{ steps.chart_version.outputs.version }}"
+          BRANCH="chore/update-vikunja-${APP_VERSION}"
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
+          git checkout -b "$BRANCH"
           git add Chart.yaml
           git commit -m "chore: update appVersion to ${APP_VERSION}"
-          git tag -a "v${CHART_VERSION}" -m "v${CHART_VERSION}"
-          git push origin main
-          git push origin "v${CHART_VERSION}"
+          git push origin "$BRANCH"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+
+      - name: Create pull request
+        if: steps.compare.outputs.needs_update == 'true' && steps.check_tag.outputs.exists == 'false'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          APP_VERSION="${{ steps.latest_release.outputs.version }}"
+          CHART_VERSION="${{ steps.chart_version.outputs.version }}"
+
+          gh pr create \
+            --title "chore: update appVersion to ${APP_VERSION}" \
+            --body "Automated update: Vikunja \'${APP_VERSION}\' is available. Bumps chart to \'${CHART_VERSION}\'." \
+            --base main \
+            --head "${{ steps.push_branch.outputs.branch }}"

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -101,6 +101,7 @@ jobs:
 
       - name: Check if PR already exists
         id: check_pr
+        if: steps.compare.outputs.needs_update == 'true' && steps.check_tag.outputs.exists == 'false'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -109,7 +110,7 @@ jobs:
             echo "PR #$EXISTING already exists, skipping"
             echo "exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "exists=false" >> $GITHUB_OUTPUT
+            echo "exists=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Commit and push to branch


### PR DESCRIPTION
The `check-version` workflow was failing because main is a protected branch. This changes the workflow to push to a feature branch and open a PR instead.
Additionally added a check to skip if a PR for the current version already exists, to avoid duplicates on daily runs.

**Note**: after merge to main, a git tag still needs to be created manually to trigger the CI release. Happy to add a separate workflow to automate that if it'd be useful.