### PR TITLE
chore(ci): harden release version parsing

### DIFF
--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -65,17 +65,24 @@ jobs:
         if: steps.compare.outputs.needs_update == 'true'
         id: chart_version
         run: |
-          CURRENT_CHART_VERSION=$(grep '^version:' Chart.yaml | awk '{print $2}')
+          CURRENT_CHART_VERSION="$(
+            grep '^version:' Chart.yaml \
+              | awk '{print $2}' \
+              | tr -d "'\"" \
+              | sed -E 's/^v//'
+          )"
+          
           # Bump the minor version and reset patch to 0
           MAJOR=$(echo "$CURRENT_CHART_VERSION" | cut -d. -f1)
           MINOR=$(echo "$CURRENT_CHART_VERSION" | cut -d. -f2)
-          NEW_CHART_VERSION="${MAJOR}.$((MINOR + 1)).0"
+          NEXT_MINOR=$((MINOR + 1))
+          NEW_CHART_VERSION="${MAJOR}.${NEXT_MINOR}.0"
 
           # If this tag already exists, keep bumping until we find a free one
           while git rev-parse "refs/tags/v${NEW_CHART_VERSION}" >/dev/null 2>&1; do
             echo "Tag v${NEW_CHART_VERSION} already exists, bumping again"
-            MINOR=$((MINOR + 1))
-            NEW_CHART_VERSION="${MAJOR}.$((MINOR + 1)).0"
+            NEXT_MINOR=$((NEXT_MINOR + 1))
+            NEW_CHART_VERSION="${MAJOR}.${NEXT_MINOR}.0"
           done
 
           echo "Chart version: $CURRENT_CHART_VERSION -> $NEW_CHART_VERSION"

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -25,13 +25,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          RELEASE_INFO=$(gh api repos/go-vikunja/vikunja/releases --jq '.[0]')
-          LATEST_VERSION=$(echo "$RELEASE_INFO" | jq -r '.tag_name')
-
-          # Strip 'v' prefix if present
-          LATEST_VERSION="${LATEST_VERSION#v}"
-
-          echo "Latest upstream version: $LATEST_VERSION"
+          LATEST_VERSION="$(
+            gh release view \
+              --repo go-vikunja/vikunja \
+              --json tagName \
+              --jq '.tagName' \
+            | sed -E 's/^v//'
+          )"
           echo "version=$LATEST_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Get current version

--- a/.github/workflows/check-version.yml
+++ b/.github/workflows/check-version.yml
@@ -37,7 +37,12 @@ jobs:
       - name: Get current version
         id: current_version
         run: |
-          CURRENT_VERSION=$(grep '^appVersion:' Chart.yaml | awk '{print $2}')
+          CURRENT_VERSION="$(
+            grep '^appVersion:' Chart.yaml \
+              | awk '{print $2}' \
+              | tr -d "'\"" \
+              | sed -E 's/^v//'
+          )"
 
           echo "Current version: $CURRENT_VERSION"
           echo "version=$CURRENT_VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This PR hardens version parsing in the release workflow.

Changes:
- normalizes appVersion values read from Chart.yaml before comparison
- normalizes chart version values before deriving the next chart version
- simplifies latest upstream release lookup with gh release view

The current Chart.yaml format does not trigger this issue; this change makes the workflow more resilient to future formatting changes.
