### PR TITLE
fix(README): corrected envFrom example

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,7 +278,7 @@ you can simplify passing multiple values to this:
 vikunja:
   envFrom:
     - secretRef:
-      name: vikunja-secret-env
+        name: vikunja-secret-env
   env:
     VIKUNJA_DATABASE_USERNAME: "db-user"
 ```


### PR DESCRIPTION
The indentation for `secretRef.name` was missing 2 spaces resulting in error.

This resulted in the following error:
```
spec.template.spec.containers[0].envFrom: Invalid value: "": must specify one of: `configMapRef` or `secretRef`
```

I deleted my fork a bit too early hence my previous PR (#29) was closed. :)