### PR TITLE
Update config.yml formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ vikunja:
     config:
       enabled: true
       data:
-        config.yml:
+        config.yml: |
           service:
             enableregistration: false
 ```


### PR DESCRIPTION
As demonstrated in `values.yaml`, the value of `config.yml` must be a string.

Without the |, YAML interprets the indented content as a nested object/map. ConfigMap's data field requires string values, so Kubernetes rejected it with "expected string, got &value.valueUnstructured".